### PR TITLE
Command handler

### DIFF
--- a/Client.cpp
+++ b/Client.cpp
@@ -3,10 +3,6 @@
 //
 
 #include "Client.hpp"
-#include <utility>
-#include <iostream>
-#include <sstream>
-#include "MessageHandler.hpp"
 
 Client::Client(int fd, std::string hostname) : _registered(false), _connected(false), _clientFd(fd), _hostname(hostname), _nickname(), _username(), _channels()
 {}

--- a/Client.cpp
+++ b/Client.cpp
@@ -1,8 +1,9 @@
 //
 // Created by Lucas on 24-Feb-23.
 //
-
 #include "Client.hpp"
+#include "MessageHandler.hpp"
+#include "utils.hpp"
 
 Client::Client(int fd, std::string hostname) : _registered(false), _connected(false), _clientFd(fd), _hostname(hostname), _nickname(), _username(), _channels()
 {}

--- a/Client.hpp
+++ b/Client.hpp
@@ -9,6 +9,10 @@
 #include <list>
 #include <map>
 #include "Channel.hpp"
+#include <utility>
+#include <iostream>
+#include <sstream>
+#include "MessageHandler.hpp"
 
 class TcpListener;
 

--- a/Client.hpp
+++ b/Client.hpp
@@ -8,11 +8,12 @@
 #include <string>
 #include <list>
 #include <map>
-#include "Channel.hpp"
 #include <utility>
 #include <iostream>
 #include <sstream>
-#include "MessageHandler.hpp"
+
+#include "Channel.hpp"
+#include "TcpListener.hpp"
 
 class TcpListener;
 
@@ -33,7 +34,7 @@ public:
 	std::string get_hostname() { return _hostname.empty() ? "" : _hostname; }
 	void		get_infos();
 private:
-	Client();
+	Client() {};
 	bool 								_registered;
 	bool								_connected;
     int                                 _clientFd;

--- a/CommandHandler.hpp
+++ b/CommandHandler.hpp
@@ -7,14 +7,12 @@
 
 #include "TcpListener.hpp"
 #include "Client.hpp"
+//#include "MessageHandler.hpp"
 
 class Client;
 
 typedef void(*CommandHandler)(Client &, int, const std::string);
 std::map<std::string, CommandHandler> commandMap;
-
-
-
 
 void handleJoin(Client &client, int argc, const std::string argv) { /* ... */ }
 void handleNick(Client &client, int argc, const std::string argv) { /* ... */ }

--- a/CommandHandler.hpp
+++ b/CommandHandler.hpp
@@ -7,7 +7,6 @@
 
 #include "TcpListener.hpp"
 #include "Client.hpp"
-//#include "MessageHandler.hpp"
 
 class Client;
 

--- a/CommandHandler.hpp
+++ b/CommandHandler.hpp
@@ -1,0 +1,33 @@
+//
+// Created by Lucas Dominique on 3/28/23.
+//
+
+#ifndef COMMAND_HANDLER_HPP
+#define COMMAND_HANDLER_HPP
+
+#include "TcpListener.hpp"
+#include "Client.hpp"
+
+class Client;
+
+typedef void(*CommandHandler)(Client &, int, const std::string);
+std::map<std::string, CommandHandler> commandMap;
+
+
+
+
+void handleJoin(Client &client, int argc, const std::string argv) { /* ... */ }
+void handleNick(Client &client, int argc, const std::string argv) { /* ... */ }
+void handleQuit(Client &client, int argc, const std::string argv) { /* ... */ }
+void handlePing(Client &client, int argc, const std::string argv) {
+	//MessageHandler::HandleMessage(client.get_fd(), ":127.0.0.1 PONG " + client.get_hostname() + " :" + client.get_nick());
+}
+
+void populateCommands() {
+	commandMap["JOIN"] = &handleJoin;
+	commandMap["NICK"] = &handleNick;
+	commandMap["QUIT"] = &handleQuit;
+	commandMap["PING"] = &handlePing;
+};
+
+#endif

--- a/MessageHandler.cpp
+++ b/MessageHandler.cpp
@@ -1,7 +1,6 @@
 //
 // Created by Lucas on 23-Feb-23.
 //
-
 #include "MessageHandler.hpp"
 
 void MessageHandler::HandleMessage(int socketId, const std::string &msg) {

--- a/MessageHandler.hpp
+++ b/MessageHandler.hpp
@@ -5,8 +5,8 @@
 #ifndef MESSAGEHANDLER_HPP
 #define MESSAGEHANDLER_HPP
 
-#include "TcpListener.hpp"
 #include <iostream>
+#include "TcpListener.hpp"
 
 class MessageHandler {
 public:

--- a/TcpListener.cpp
+++ b/TcpListener.cpp
@@ -262,14 +262,18 @@ void TcpListener::_process_msg(const std::string& msg, Client	&client)
 	}
 	else // all commands after registration
 	{
+		//todo:
+		//parse msg
+
+		//check command
+
+		//call command
+
 		std::map<std::string, CommandHandler>::iterator iter = commandMap.find(msg);
 		if (iter == commandMap.end()){
 			// not found
 			return;
 		}
-
-		CommandHandler handler = iter->second;
-		handler(client, 0, msg);
 //		if (msg.find("USER") == 0) { // todo: maybe use realname (write a getter), instead of nickname in this error message
 //			MessageHandler::numericReply(client.get_fd(), "462", client.get_nick() + ":You may not reregister");
 //		}

--- a/TcpListener.cpp
+++ b/TcpListener.cpp
@@ -262,12 +262,20 @@ void TcpListener::_process_msg(const std::string& msg, Client	&client)
 	}
 	else // all commands after registration
 	{
-		if (msg.find("USER") == 0) { // todo: maybe use realname (write a getter), instead of nickname in this error message
-			MessageHandler::numericReply(client.get_fd(), "462", client.get_nick() + ":You may not reregister");
-		}
-		if (msg.find("PING") == 0) {
-			MessageHandler::HandleMessage(client.get_fd(), ":127.0.0.1 PONG " + client.get_hostname() + " :" + client.get_nick());
-		}
+//		std::map<std::string, CommandHandler>::iterator iter = commandMap.find(msg);
+//		if (iter == commandMap.end()){
+//			// not found
+//			return;
+//		}
+//
+//		CommandHandler handler = iter->second;
+//		handler(client, 0, msg);
+//		if (msg.find("USER") == 0) { // todo: maybe use realname (write a getter), instead of nickname in this error message
+//			MessageHandler::numericReply(client.get_fd(), "462", client.get_nick() + ":You may not reregister");
+//		}
+//		if (msg.find("PING") == 0) {
+//			MessageHandler::HandleMessage(client.get_fd(), ":127.0.0.1 PONG " + client.get_hostname() + " :" + client.get_nick());
+//		}
 	}
 }
 

--- a/TcpListener.cpp
+++ b/TcpListener.cpp
@@ -1,12 +1,18 @@
 //
 // Created by Lucas on 22-Feb-23.
 //
-
 #include "TcpListener.hpp"
-#include "utils.hpp"
 
 TcpListener::TcpListener(const std::string& ipAddress, int port)
-: _ipAddress(ipAddress), _port(port) {}
+: _ipAddress(ipAddress), _port(port) {
+	_commands[0] = "NICK";
+	_commands[1] = "USER";
+	_commands[2] = "JOIN";
+	_commands[3] = "PART";
+	_commands[4] = "PRIVMSG";
+	_commands[5] = "PING";
+	_commands[6] = "EXIT";
+}
 
 TcpListener::~TcpListener() {}
 
@@ -264,23 +270,39 @@ void TcpListener::_process_msg(const std::string& msg, Client	&client)
 	{
 		//todo:
 		//parse msg
-
-		//check command
+		std::istringstream iss(msg);
+		std::string cmd;
+		iss >> cmd;
+		// parse params
+		std::vector<std::string> params;
+		for (std::string param; iss >> param;)
+			params.push_back(param);
+		// print out params content to check
+		for (std::vector<std::string>::iterator it = params.begin(); it != params.end(); ++it)
+			std::cout << *it << std::endl;
 
 		//call command
-
-		std::map<std::string, CommandHandler>::iterator iter = commandMap.find(msg);
-		if (iter == commandMap.end()){
-			// not found
-			return;
+		if (cmd == "PING") { // todo: move it in PRIVMSG scope
+			MessageHandler::HandleMessage(client.get_fd(),
+										  ":127.0.0.1 PONG " + client.get_hostname() + " :" + client.get_nick());
 		}
+		if (cmd == "NICK") {
+			if (!client.set_nickname(msg, this->_clients, *this))
+				_handle_error("other nickname error");
+		}
+		if (cmd == "JOIN") {
+			_handle_join(client, params);
+		}
+		if (cmd == "PRIVMSG") {
+			_handle_privmsg(client, params);
+		}
+	}
+//
 //		if (msg.find("USER") == 0) { // todo: maybe use realname (write a getter), instead of nickname in this error message
 //			MessageHandler::numericReply(client.get_fd(), "462", client.get_nick() + ":You may not reregister");
 //		}
 //		if (msg.find("PING") == 0) {
-//			MessageHandler::HandleMessage(client.get_fd(), ":127.0.0.1 PONG " + client.get_hostname() + " :" + client.get_nick());
 //		}
-	}
 }
 
 void TcpListener::_handle_error(const char *msg) {
@@ -316,4 +338,32 @@ Client& TcpListener::get_client(int client_fd) {
     }
 
     throw std::runtime_error("Client not found"); // or return some default value instead of throwing an exception
+}
+
+void TcpListener::_handle_join(Client &client, std::vector<std::string> &params)
+{
+	if (params.empty())
+		MessageHandler::numericReply(client.get_fd(), "461", "JOIN :Not enough parameters");
+	else if (params.size() > 1)
+		MessageHandler::numericReply(client.get_fd(), "461", "JOIN :Too many parameters");
+	else
+	{
+		if (params[0][0] != '&')
+			MessageHandler::numericReply(client.get_fd(), "403", params[0] + " :No such channel");
+		else
+		{ // handle multi-channels or not? If yes, how? This version doesn't handle it
+			//					if (client.get_channel() != NULL)
+			//						client.get_channel()->remove_client(client.get_fd());
+			//					client.set_channel(this->_channels[params[0]]);
+			//					client.get_channel()->add_client(client.get_fd());
+			MessageHandler::HandleMessage(client.get_fd(), ":" + client.get_nick() + "!" + client.get_username() + "@" +
+										  client.get_hostname() + " JOIN " + params[0]);
+			// todo: verify that this copilot generated message makes any sense
+		}
+	}
+}
+
+void TcpListener::_handle_privmsg(Client &client, std::vector<std::string> &vector1)
+{
+
 }

--- a/TcpListener.cpp
+++ b/TcpListener.cpp
@@ -262,14 +262,14 @@ void TcpListener::_process_msg(const std::string& msg, Client	&client)
 	}
 	else // all commands after registration
 	{
-//		std::map<std::string, CommandHandler>::iterator iter = commandMap.find(msg);
-//		if (iter == commandMap.end()){
-//			// not found
-//			return;
-//		}
-//
-//		CommandHandler handler = iter->second;
-//		handler(client, 0, msg);
+		std::map<std::string, CommandHandler>::iterator iter = commandMap.find(msg);
+		if (iter == commandMap.end()){
+			// not found
+			return;
+		}
+
+		CommandHandler handler = iter->second;
+		handler(client, 0, msg);
 //		if (msg.find("USER") == 0) { // todo: maybe use realname (write a getter), instead of nickname in this error message
 //			MessageHandler::numericReply(client.get_fd(), "462", client.get_nick() + ":You may not reregister");
 //		}

--- a/TcpListener.hpp
+++ b/TcpListener.hpp
@@ -13,16 +13,14 @@
 #include <sys/poll.h>
 #include <list>
 
+#include "Modifier.hpp"
+#include "Numeric_replies.hpp"
 #include "utils.hpp"
 #include "MessageHandler.hpp"
 #include "Client.hpp"
-#include "Modifier.hpp"
-#include "Numeric_replies.hpp"
-#include "CommandHandler.hpp"
 
 #define BUF_SIZE 1024
 
-//class MessageHandler;
 class Client;
 
 class TcpListener {
@@ -59,6 +57,11 @@ private:
     std::list<Client *>     	_clients;
 	int     					_nfds;
 	struct pollfd       		_fds[10];
+	std::string 				_commands[20];
+
+	void _handle_join(Client &client, std::vector<std::string> &params);
+
+	void _handle_privmsg(Client &client, std::vector<std::string> &vector1);
 };
 
 #endif

--- a/TcpListener.hpp
+++ b/TcpListener.hpp
@@ -18,6 +18,7 @@
 #include "Client.hpp"
 #include "Modifier.hpp"
 #include "Numeric_replies.hpp"
+#include "CommandHandler.hpp"
 
 #define BUF_SIZE 1024
 

--- a/TcpListener.hpp
+++ b/TcpListener.hpp
@@ -22,7 +22,8 @@
 
 #define BUF_SIZE 1024
 
-class MessageHandler;
+//class MessageHandler;
+class Client;
 
 class TcpListener {
 public:

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,5 @@
 
 #include "TcpListener.hpp"
-#include "CommandHandler.hpp"
 
 int main() {
     //    if (argc != 3) {
@@ -9,7 +8,6 @@ int main() {
     //    }
 
     TcpListener server("127.0.0.1", 6667);
-	populateCommands();
     server.Run();
 
     return 0;

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,6 @@
 
 #include "TcpListener.hpp"
+#include "CommandHandler.hpp"
 
 int main() {
     //    if (argc != 3) {

--- a/main.cpp
+++ b/main.cpp
@@ -8,7 +8,7 @@ int main() {
     //    }
 
     TcpListener server("127.0.0.1", 6667);
-
+	populateCommands();
     server.Run();
 
     return 0;

--- a/utils.hpp
+++ b/utils.hpp
@@ -5,7 +5,6 @@
 #ifndef FT_IRC_UTILS_HPP
 #define FT_IRC_UTILS_HPP
 
-#include "TcpListener.hpp"
 #include <string>
 
 void	_skip_line(std::string &msg);


### PR DESCRIPTION
We have less unecessary includes than before.
- Added _commands string array to store names of supported array (which we can use to do a switch case)
- Added an isstringstream object to pre-parse the commands. We pop out of it the first word, which is the command, into a cmd string, then pop out every subsequent space-separated word (in case of non-space separated elements, we can parse those laters in _handle_cmd_name() functions.