### PR TITLE
Feature/privmsg

### DIFF
--- a/Channel.cpp
+++ b/Channel.cpp
@@ -11,3 +11,15 @@ Channel::Channel(std::string name) : _name(name), _topic(), _users() {
 Channel::~Channel() {
 
 }
+
+bool Channel::send_message(std::string nick, std::string &msg)
+{
+	std::cout << "send_message got " << msg << " from " << nick;
+	// DO ALL SORTS OF SHENANIGANS
+//	std::vector<Client *>::iterator it = _users.begin();
+//	for (; it != _users.end(); it++)
+//	{
+//
+//	}
+	return false;
+}

--- a/Channel.hpp
+++ b/Channel.hpp
@@ -8,17 +8,21 @@
 
 #include <string>
 #include <vector>
+#include <iostream>
+
+class Client;
 
 class Channel {
 public:
     Channel(std::string name);
     ~Channel();
 
-	std::string get_name() const { return _name; };
+	std::string get_name() {return _name;};
+	bool		send_message(std::string nick, std::string &msg);
 private:
     std::string _name;
     std::string _topic;
-    std::vector<std::string> _users;
+    std::vector<Client *> _users;
 };
 
 

--- a/Channel.hpp
+++ b/Channel.hpp
@@ -14,6 +14,7 @@ public:
     Channel(std::string name);
     ~Channel();
 
+	std::string get_name() const { return _name; };
 private:
     std::string _name;
     std::string _topic;

--- a/MessageHandler.cpp
+++ b/MessageHandler.cpp
@@ -12,3 +12,8 @@ void MessageHandler::numericReply(int client_fd, std::string numeric, std::strin
 	std::string reply = ":127.0.0.1 " + numeric + " " + message + "\r\n";
 	TcpListener::Send(client_fd, reply);
 }
+
+void MessageHandler::send_to_client(std::string dest, std::string message)
+{
+
+}

--- a/MessageHandler.cpp
+++ b/MessageHandler.cpp
@@ -13,7 +13,10 @@ void MessageHandler::numericReply(int client_fd, std::string numeric, std::strin
 	TcpListener::Send(client_fd, reply);
 }
 
-void MessageHandler::send_to_client(std::string dest, std::string message)
+void MessageHandler::send_to_client(std::string &dest, std::string message)
 {
-
+	std::string trimmed = message.substr(1); // REMOVE the ":" prefix
+	// FIND CLIENT USING NICKNAME
+	std::cout << "send_to_client got " << trimmed << " to send to " << dest;
+	// SEND MESSAGE TO CLIENT
 }

--- a/MessageHandler.hpp
+++ b/MessageHandler.hpp
@@ -12,7 +12,7 @@ class MessageHandler {
 public:
     static void HandleMessage(int socketId, const std::string &msg);
 	static void	numericReply(int client_fd, std::string numeric, std::string message);
-	static void send_to_client(std::string dest, std::string msg);
+	static void send_to_client(std::string &dest, std::string msg);
 };
 
 

--- a/MessageHandler.hpp
+++ b/MessageHandler.hpp
@@ -12,6 +12,7 @@ class MessageHandler {
 public:
     static void HandleMessage(int socketId, const std::string &msg);
 	static void	numericReply(int client_fd, std::string numeric, std::string message);
+	static void send_to_client(std::string dest, std::string msg);
 };
 
 

--- a/TcpListener.cpp
+++ b/TcpListener.cpp
@@ -256,7 +256,7 @@ void TcpListener::_connection(Client &client) {
 
 }
 
-void TcpListener::_exec_command(Client &client, const std::string& cmd, const std::vector<std::string>& params) {
+void TcpListener::_exec_command(Client &client, const std::string& cmd, std::vector<std::string> &params) {
 	std::string valid_commands[4] = {
 		"PING",
 		"PRIVMSG",

--- a/TcpListener.cpp
+++ b/TcpListener.cpp
@@ -282,10 +282,6 @@ void TcpListener::_process_msg(const std::string& msg, Client	&client)
 			std::cout << *it << std::endl;
 
 		//call command
-		if (cmd == "PING") { // todo: move it in PRIVMSG scope
-			MessageHandler::HandleMessage(client.get_fd(),
-										  ":127.0.0.1 PONG " + client.get_hostname() + " :" + client.get_nick());
-		}
 		if (cmd == "NICK") {
 			if (!client.set_nickname(msg, this->_clients, *this))
 				_handle_error("other nickname error");
@@ -318,6 +314,17 @@ bool TcpListener::_nickname_available(std::string &nick)
 			return (false);
 	}
 	return (true);
+}
+
+bool TcpListener::_channel_available(std::string &chan_name)
+{
+	std::list<Channel *>::iterator it;
+
+	for (it = this->_channels.begin(); it != this->_channels.end(); it++){
+		if (!chan_name.empty() && chan_name == ((*it))->get_name())
+			return (false);
+	}
+	return false;
 }
 
 void TcpListener::delete_client(int client_fd) {
@@ -363,7 +370,17 @@ void TcpListener::_handle_join(Client &client, std::vector<std::string> &params)
 	}
 }
 
-void TcpListener::_handle_privmsg(Client &client, std::vector<std::string> &vector1)
+void TcpListener::_handle_privmsg(Client &client, std::vector<std::string> &params)
 {
-
+	if (_nickname_available(params[0])) { // MESSAGE TO USER
+	}
+	else if (is_channel(params[1])) { // MESSAGE TO CHANNEL
+	}
+	else {
+		MessageHandler::numericReply(client.get_fd(), "401", params[0] + " :No such nick/channel");
+	}
+//	if (cmd == "PING") { // todo: move it in PRIVMSG scope
+//		MessageHandler::HandleMessage(client.get_fd(),
+//									  ":127.0.0.1 PONG " + client.get_hostname() + " :" + client.get_nick());
+//	}
 }

--- a/TcpListener.hpp
+++ b/TcpListener.hpp
@@ -40,6 +40,7 @@ public:
 	}
 	void			delete_client(int	client_fd);
 	Client&			get_client(int client_fd);
+	Client&			get_client(std::string	&nick);
 	bool 			_nickname_available(std::string &nick);
 	Channel*		_is_channel(std::string &chan_name);
 private:

--- a/TcpListener.hpp
+++ b/TcpListener.hpp
@@ -41,6 +41,7 @@ public:
 	void			delete_client(int	client_fd);
 	Client&			get_client(int client_fd);
 	bool 			_nickname_available(std::string &nick);
+	bool 			_channel_available(std::string &chan_name);
 private:
     int             _CreateSocket() const;
     void            _WaitForConnection(int listening_fd);
@@ -55,13 +56,14 @@ private:
     std::string                 _ipAddress;
     int                         _port;
     std::list<Client *>     	_clients;
+	std::list<Channel *>		_channels;
 	int     					_nfds;
 	struct pollfd       		_fds[10];
 	std::string 				_commands[20];
 
 	void _handle_join(Client &client, std::vector<std::string> &params);
 
-	void _handle_privmsg(Client &client, std::vector<std::string> &vector1);
+	void _handle_privmsg(Client &client, std::vector<std::string> &params);
 };
 
 #endif

--- a/TcpListener.hpp
+++ b/TcpListener.hpp
@@ -41,7 +41,7 @@ public:
 	void			delete_client(int	client_fd);
 	Client&			get_client(int client_fd);
 	bool 			_nickname_available(std::string &nick);
-	bool 			_channel_available(std::string &chan_name);
+	Channel*		_is_channel(std::string &chan_name);
 private:
     int             _CreateSocket() const;
     void            _WaitForConnection(int listening_fd);
@@ -62,7 +62,6 @@ private:
 	std::string 				_commands[20];
 
 	void _handle_join(Client &client, std::vector<std::string> &params);
-
 	void _handle_privmsg(Client &client, std::vector<std::string> &params);
 };
 

--- a/TcpListener.hpp
+++ b/TcpListener.hpp
@@ -53,7 +53,7 @@ private:
 	static void		_connection(Client &client);
 	int 			_handle_new_connection(int listening_fd);
 	int 			_handle_message(int i);
-	static void		_exec_command(Client &client, const std::string& cmd, const std::vector<std::string>& params);
+	void		_exec_command(Client &client, const std::string& cmd, std::vector<std::string> &params);
 
     std::string                 _ipAddress;
     int                         _port;


### PR DESCRIPTION
Lots of cool stuff
- Created the basic structure of _handle_privmsg
   - detecs if msg is destined to user or channel, if channel, checks if chan name exists (only matches if prefixed with local channel identifier `&`)
-  added two placeholder methods
  - MessageHandler::send_to_client
  - Channel::send_message
To test it, try connecting, typing /join &anyChannelName, then writing anything you want (which irssi interprets as `/PRIVMSG &chanName anything you want`, you will see it's correctly parsed server side (debug messages in placeholder methods).
Also you can send a message to someone with `/MSG pseudoNickname salut`, which will be parsed. The condition must not be correct (will fix) since it seems to match with non-existing users.

[ ] All error messages have been auto-generated and I have not checked, must verify.
[ ] Re-test by trying to make it fail