### PR TITLE
Feature/privmsg

### DIFF
--- a/CommandHandler.hpp
+++ b/CommandHandler.hpp
@@ -10,6 +10,7 @@
 //void join(int client_fd, std::vector<std::string> params);
 //void nick(int client_fd, std::vector<std::string> params);
 void ping(int client_fd, std::vector<std::string> params);
+void _mode(int fd, std::vector<std::string> params);
 //void privmsg(int client_fd, std::vector<std::string> params);
 
 #endif

--- a/MessageHandler.cpp
+++ b/MessageHandler.cpp
@@ -16,10 +16,12 @@ void MessageHandler::numericReply(int client_fd, std::string numeric, std::strin
 void MessageHandler::send_to_client(std::string sender, std::vector<std::string> &params, TcpListener *SERV)
 {
 	std::string message = params[1];
-	// concatenate params 1 to n into string msg if it's fragmented
+	std::cout << "message: " << message << std::endl;
+	// concatenate params 2 (because is already in message) to n into string msg if it's fragmented
 	if (params.size() > 2) {
-		for (std::vector<std::string>::iterator it = params.begin(); it != params.end(); it++)
-			message += *it;
+		std::vector<std::string>::iterator it = params.begin(); it += 2;
+		for (; it != params.end(); it++)
+			message += " " + *it;
 	}
 	// FIND CLIENT USING NICKNAME
 	Client&	client = SERV->get_client(params[0]);

--- a/MessageHandler.cpp
+++ b/MessageHandler.cpp
@@ -13,10 +13,23 @@ void MessageHandler::numericReply(int client_fd, std::string numeric, std::strin
 	TcpListener::Send(client_fd, reply);
 }
 
-void MessageHandler::send_to_client(std::string &dest, std::string message)
+void MessageHandler::send_to_client(std::string sender, std::vector<std::string> &params, TcpListener *SERV)
 {
+	std::string message = params[1];
+	// concatenate params 1 to n into string message
+	if (params.size() > 2) {
+		for (std::vector<std::string>::iterator it = params.begin(); it != params.end(); it++)
+			message += *it;
+	}
+
 	std::string trimmed = message.substr(1); // REMOVE the ":" prefix
 	// FIND CLIENT USING NICKNAME
-	std::cout << "send_to_client got " << trimmed << " to send to " << dest;
-	// SEND MESSAGE TO CLIENT
+	Client&	client = SERV->get_client(params[0]);
+	std::cout << client.get_fd() << std::endl;
+	// SEND REFORMATED MESSAGE TO CLIENT
+	std::cout << "message " + message + "$" << std::endl;
+	std::string reform = ":" + sender + " PRIVMSG " + client.get_nick() + " " + message + "\r\n";
+
+	std::cout << reform << std::endl;
+	MessageHandler::HandleMessage(client.get_fd(), reform);
 }

--- a/MessageHandler.cpp
+++ b/MessageHandler.cpp
@@ -16,20 +16,15 @@ void MessageHandler::numericReply(int client_fd, std::string numeric, std::strin
 void MessageHandler::send_to_client(std::string sender, std::vector<std::string> &params, TcpListener *SERV)
 {
 	std::string message = params[1];
-	// concatenate params 1 to n into string message
+	// concatenate params 1 to n into string msg if it's fragmented
 	if (params.size() > 2) {
 		for (std::vector<std::string>::iterator it = params.begin(); it != params.end(); it++)
 			message += *it;
 	}
-
-	std::string trimmed = message.substr(1); // REMOVE the ":" prefix
 	// FIND CLIENT USING NICKNAME
 	Client&	client = SERV->get_client(params[0]);
 	std::cout << client.get_fd() << std::endl;
 	// SEND REFORMATED MESSAGE TO CLIENT
-	std::cout << "message " + message + "$" << std::endl;
 	std::string reform = ":" + sender + " PRIVMSG " + client.get_nick() + " " + message + "\r\n";
-
-	std::cout << reform << std::endl;
 	MessageHandler::HandleMessage(client.get_fd(), reform);
 }

--- a/MessageHandler.hpp
+++ b/MessageHandler.hpp
@@ -8,11 +8,13 @@
 #include <iostream>
 #include "TcpListener.hpp"
 
+class TcpListener;
+
 class MessageHandler {
 public:
     static void HandleMessage(int socketId, const std::string &msg);
 	static void	numericReply(int client_fd, std::string numeric, std::string message);
-	static void send_to_client(std::string &dest, std::string msg);
+	static void send_to_client(std::string sender, std::vector<std::string> &params, TcpListener *SERV);
 };
 
 

--- a/Numeric_replies.hpp
+++ b/Numeric_replies.hpp
@@ -5,11 +5,11 @@
 #ifndef FT_IRC_NUMERIC_REPLIES_HPP
 #define FT_IRC_NUMERIC_REPLIES_HPP
 
-#define user_id(nickname, username) (":" + nickname + "!" + username + "@localhost")
+#define user_id(nickname, username) (nickname + "!" + username + "@localhost")
 #define RPL_WELCOME(user_id, nick) (":localhost 001 " + nick + " :Welcome to the COOL IRC Network, " + user_id + "\r\n")
 #define RPL_YOURHOST(nick) (":localhost 002 " + nick + " :Your host is localhost, running version DEV.1\r\n")
 #define RPL_CREATED(datetime) (":localhost 003 " + nick + " :This server was created " + datetime + "\r\n")
-#define RPL_MYINFO() (":localhost 004 <servername> <version> <available user modes>" "<available channel modes> [<channel modes with a parameter>]\r\n")
+#define RPL_MYINFO() (":localhost 004 gigacoolchat 0.0.1 +i +i\r\n")
 
 #define RPL_MOTDSTART(client) (":localhost 375 " + client + " :- localhost Message of the day - \r\n")
 #define RPL_MOTD(client, motd_line) (":localhost 372 " + client + " :" + motd_line + "\r\n")

--- a/TcpListener.cpp
+++ b/TcpListener.cpp
@@ -234,6 +234,9 @@ void TcpListener::_registration(std::string msg, Client &client) {
 	client.set_registered();
 }
 
+
+#include <thread>
+#include <chrono>
 void TcpListener::_connection(Client &client) {
 
 	std::string nick = client.get_nick();
@@ -252,21 +255,25 @@ void TcpListener::_connection(Client &client) {
 			RPL_ENDOFMOTD(nick);
 	MessageHandler::HandleMessage(client.get_fd(), msg);
 
+	std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+
 	client.set_connected();
 
 }
 
 void TcpListener::_exec_command(Client &client, const std::string& cmd, std::vector<std::string> &params) {
-	std::string valid_commands[4] = {
+	std::string valid_commands[5] = {
 		"PING",
 		"PRIVMSG",
+		"MODE",
 		"JOIN",
-		"NICK",
+		"NICK"
 	};
 
 	int idx = 0;
 
-	while (idx < 4) {
+	while (idx < 5) {
 		if (cmd == valid_commands[idx])
 			break;
 		idx++;
@@ -274,25 +281,24 @@ void TcpListener::_exec_command(Client &client, const std::string& cmd, std::vec
 	switch (idx + 1) {
 		case 1: ping(client.get_fd(), params); break;
 		case 2: _handle_privmsg(client, params); break;
-//		case 1: join(client.get_fd(), params); break;
-//		case 2: nick(client.get_fd(), params); break;
+		case 3: _mode(client.get_fd(), params); break;
+//		case 3: join(client.get_fd(), params); break;
+//		case 4: nick(client.get_fd(), params); break;
 	}
 }
 
 void TcpListener::_process_msg(const std::string& msg, Client	&client)
 {
-	if (!client.is_registered())
+	if (!client.is_registered()) // connection procedure
 		_registration(msg, client);
 	if (!client.is_connected())
 		_connection(client);
 	else // all commands after registration
 	{
-		//todo:
-		//parse msg
 		std::istringstream iss(msg);
 		std::string cmd;
 		iss >> cmd;
-		// parse params
+
 		std::vector<std::string> params;
 		for (std::string param; iss >> param;)
 			params.push_back(param);
@@ -396,8 +402,8 @@ void TcpListener::_handle_privmsg(Client &client, std::vector<std::string> &para
 	if (chan){
 		chan->send_message(client.get_nick(), params[1]);
 	}
-	else if (_nickname_available(params[0]))
-		MessageHandler::send_to_client(params[0], params[1]);
+	else if (!_nickname_available(params[0]))
+		MessageHandler::send_to_client(client.get_nick(), params, this);
 	else {
 		MessageHandler::numericReply(client.get_fd(), "401", params[0] + " :No such nick/channel");}
 }

--- a/TcpListener.cpp
+++ b/TcpListener.cpp
@@ -18,7 +18,7 @@ TcpListener::TcpListener(const std::string& ipAddress, int port)
 TcpListener::~TcpListener() {}
 
 void TcpListener::Send(int clientSocket, const std::string& msg) {
-    send(clientSocket, msg.c_str(), msg.size() + 1, 0);
+    send(clientSocket, msg.c_str(), msg.size(), 0);
 }
 
 void TcpListener::Run() {

--- a/ping.cpp
+++ b/ping.cpp
@@ -7,6 +7,13 @@
 
 void ping(int client_fd, std::vector<std::string> params) {
 	MessageHandler::HandleMessage(client_fd,
-								  ":127.0.0.1 PONG");
+								  ":localhost PONG localhost :sbars\r\n");
 	std::cout << "PONG" << std::endl;
+}
+
+void _mode(int fd, std::vector<std::string> params)
+{
+	MessageHandler::HandleMessage(fd,
+								  ":sbars MODE sbars :+i\r\n");
+	std::cout << "mode" << std::endl;
 }


### PR DESCRIPTION
Unveiling the /msg function, for client-to-client communication (client-to-channel coming soon!).
Starts with the _handle_privmsg function, which redirects to the send_to_client function, which will find the client object matching the destination nickname, and reformat the message before sending it to the target

We also fixed a considerable communication problem. In the send function, we were passing a size argument of msg.size() + 1. The + 1 was unnecessary, and the client's buffer was waiting endlessly for a terminating `\r\n`, making it impossible to read any subsequent messages.
Since that is fixed our PONG and MODE responses are successfully received.