### PR TITLE
QUIT command now working as it should.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,10 @@ add_executable(ft_irc
         CommandHandler.hpp
         commands/join.cpp
         commands/ping.cpp
-        commands/names.cpp)
+        commands/names.cpp
+        commands/motd.cpp
+        commands/mode.cpp
+        commands/oper.cpp
+        )
 
 add_definitions(-DCATCH_CONFIG_MAIN)

--- a/Channel.cpp
+++ b/Channel.cpp
@@ -26,7 +26,7 @@ Channel::~Channel() {
 
 }
 
-bool Channel::send_message(std::string sender, std::vector<std::string> &params)
+bool Channel::send_privmsg(std::string sender, std::vector<std::string> &params)
 {
 	// reformat message before sending
 	std::string message = ":" + sender + " PRIVMSG "; // + _name + " :" + params[1] + "\r\n";
@@ -35,12 +35,17 @@ bool Channel::send_message(std::string sender, std::vector<std::string> &params)
 		message += *it + " ";
 	std::cout << "msg for chan: " << message << std::endl;
 	// send message to all users in channel
+	send_to_users(sender, message, false);
+	return false;
+}
+
+void Channel::send_to_users(std::string sender, std::string message, bool self)
+{
 	for (std::vector<Client *>::iterator it = _users.begin(); it != _users.end(); it++)
 	{
-		if ((*it)->get_nick() != sender)
+		if (!self && (*it)->get_nick() != sender)
 			MessageHandler::HandleMessage((*it)->get_fd(), message + "\r\n");
 	}
-	return false;
 }
 
 void Channel::add_user(Client *client) {
@@ -65,7 +70,7 @@ bool Channel::is_user_in_channel(int fd)
 
 void Channel::remove_user(int fd)
 {
-	for (std::vector<Client*>::iterator it = _users.begin(); it != _users.end(); ++it) {
+	for (std::vector<Client*>::iterator it = _users.begin(); it != _users.end(); it++) {
 		if ((*it)->get_fd() == fd) {
 			std::cout << "removing user " << (*it)->get_nick() << std::endl;
 			_users.erase(it);

--- a/Channel.hpp
+++ b/Channel.hpp
@@ -29,7 +29,8 @@ public:
 	bool					is_user_in_channel(int fd);
 	void					remove_user(int fd);
 	void					add_operator(std::string nick);
-	bool					send_message(std::string sender, std::vector<std::string> &params);
+	bool					send_privmsg(std::string sender, std::vector<std::string> &params);
+	void					send_to_users(std::string sender, std::string message, bool self);
 private:
     std::string _name;
     std::string _topic;

--- a/Client.cpp
+++ b/Client.cpp
@@ -47,7 +47,7 @@ bool Client::set_nickname(const std::string &nick, TcpListener &SERV) {
         } else {
 			MessageHandler::HandleMessage(_clientFd, trimmed_nick + " " + trimmed_nick + " :Nickname is already in use");
 		}
-		SERV._disconnect_client(this->_clientFd);
+		SERV._disconnect_client(*this);
         return false;
     }
 }
@@ -124,15 +124,12 @@ bool Client::in_channel(const std::string& channel_name) {
 	return true;
 }
 
-void Client::leave_channel(const std::string &channel_name)
+void Client::leave_channel(Channel& channel)
 {
-	std::map<std::string, Channel *>::iterator it = _channels.find(channel_name);
-	if (it == _channels.end())
-		return;
-	Channel *channel = it->second;
-	channel->remove_user(this->get_fd());
-	_channels.erase(it);
-	MessageHandler::HandleMessage(this->get_fd(), ":" + user_id(_nickname, _username) + " PART :" + channel_name + "\r\n");
+	std::cout << "channel: " << channel.get_name() << " - user: " << this->get_nick() << " is leaving" << std::endl;
+	channel.remove_user(this->get_fd());
+	_channels.erase(channel.get_name());
+	MessageHandler::HandleMessage(this->get_fd(), ":" + user_id(_nickname, _username) + " PART :" + channel.get_name() + "\r\n");
 }
 
 void Client::set_operator() {

--- a/Client.hpp
+++ b/Client.hpp
@@ -38,7 +38,7 @@ public:
 	void								get_infos();
 	std::map<std::string, Channel *>& 	get_channels() { return _channels; }
 	void 								join_channel(Channel *channel);
-	void 								leave_channel(const std::string& channel_name);
+	void 								leave_channel(Channel &channel);
 	bool								in_channel(const std::string& channel_name);
 private:
 	Client() {};

--- a/CommandHandler.hpp
+++ b/CommandHandler.hpp
@@ -6,6 +6,7 @@
 #define COMMAND_HANDLER_HPP
 
 #include <vector>
+#include <map>
 #include "Client.hpp"
 
 void 	join(TcpListener &SERV, Client &client, std::vector<std::string> params);

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ SRCS        :=  Channel.cpp \
                 commands/ping.cpp \
                 commands/motd.cpp \
                 commands/oper.cpp \
-                commands/mode.cpp \
+                commands/mode.cpp
 
 OBJS        := ${SRCS:.cpp=.o}
 

--- a/TcpListener.cpp
+++ b/TcpListener.cpp
@@ -88,6 +88,9 @@ int TcpListener::_CreateSocket() const {
 
 void TcpListener::_disconnect_client(Client &client)
 {
+	// send ERROR message to client
+	MessageHandler::HandleMessage(client.get_fd(), "ERROR :Closing link: Client disconnected\r\n");
+
 	std::cout << "Client disconnected" << std::endl;
 	close(client.get_fd());
 	for (int i=0; i < _nfds; i++) {

--- a/TcpListener.hpp
+++ b/TcpListener.hpp
@@ -48,7 +48,7 @@ public:
 	void 			add_channel(Channel *channel);
 	void 			print_channels();
 	Channel*		_is_channel(std::basic_string<char> chan_name);
-	void			_disconnect_client(int client_fd);
+	void			_disconnect_client(Client &client);
 private:
     int             _CreateSocket() const;
     void            _WaitForConnection(int listening_fd);

--- a/commands/join.cpp
+++ b/commands/join.cpp
@@ -49,7 +49,7 @@ void join(TcpListener &SERV, Client &client, std::vector<std::string> params) {
 			for (std::vector<Client *>::iterator u_it = users.begin(); u_it != users.end(); u_it++)
 			{
 				if ((*u_it)->get_nick() != client.get_nick())
-					MessageHandler::HandleMessage((*u_it)->get_fd(), msg + "\r\n");
+					MessageHandler::HandleMessage((*u_it)->get_fd(), msg);
 			}
 			if (!channel->get_topic().empty())
 				MessageHandler::HandleMessage(client.get_fd(), RPL_TOPIC(client.get_nick(), channel_name, channel->get_topic()));


### PR DESCRIPTION
It calls the _disconnect_client function, which
- closes file descriptors
- leaves all channels the client is a member of
- removes channels from the client, client from the channel's users list
- sends the quit messages to all clients that the leaving client was in a channel with
- and every irssi instance displays departure properly as a result
![image](https://user-images.githubusercontent.com/88668425/230439510-3c4f876c-96f7-4006-932c-d298906d93ad.png)
