### PR TITLE
Buffer done (needs more testing to maybe break it though)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+
+.idea/
+
+*.o
+commands/*.o
+
+cmake-build-debug/
+
+ircserv

--- a/TcpListener.cpp
+++ b/TcpListener.cpp
@@ -152,35 +152,52 @@ int TcpListener::_handle_new_connection(int listening_fd) {
 	return 0;
 }
 
+int TcpListener::_read_data(int fd, char *buf, std::string& buffer)
+{
+	ssize_t bytes_received = recv(fd, buf, BUF_SIZE, 0);
+	if (bytes_received == -1) { // Handle error
+		return -1;
+	}
+	else if (bytes_received == 0) { // Check to see if the connection has been closed by the client
+		_disconnect_client(get_client(fd));
+		return -1;
+	}
+	buf[bytes_received] = '\0';
+	buffer += buf;
+	return 1;
+}
+
 int TcpListener::_handle_message(int i) {
+	char        buffer[BUF_SIZE];
+	std::string output;
 
-	char    buffer[BUF_SIZE];
-	ssize_t bytes_received;
-
-	std::cout << "Descriptor: " << _fds[i].fd << " is readable" << std::endl;
+	if (!get_client(_fds[i].fd).is_connected()) {
+		output = recv(_fds[i].fd, buffer, BUF_SIZE, 0);
+		_process_msg(buffer, get_client(_fds[i].fd));
+		return 0;
+	}
 
 	memset(buffer, 0, BUF_SIZE);
-
-	//Wait for client to send data
-	bytes_received = recv(_fds[i].fd, buffer, BUF_SIZE, 0);
-
-	if (bytes_received == -1) {
-		std::cout << "Connection issue" << std::endl;
+	if (_read_data(_fds[i].fd, buffer, output) == -1)
 		return -1;
-	}
+	std::cout << "Descriptor: " << _fds[i].fd << " is readable" << std::endl;
 
-	// Check to see if the connection has been closed by the client
-	if (bytes_received == 0) {
-		_disconnect_client(get_client(_fds[i].fd));
-		return -1;
+	// Wait for client to send data
+	while (!output.empty()) {
+		size_t pos = output.find("\r\n");
+		if (pos == std::string::npos) { // incomplete msg, keep reading or return on error
+			if (_read_data(_fds[i].fd, buffer, output) == -1)
+				return -1;
+		}
+		else {
+			// Complete message received, process it
+			_process_msg(output.substr(0, pos), get_client(_fds[i].fd));
+			output = output.substr(pos + 2);
+		}
 	}
-	std::cout << bytes_received << " bytes received." << std::endl;
-	std::cout << "Message received: " << std::endl
-			  << buffer << std::endl;
-	_process_msg(buffer, get_client(_fds[i].fd));
-
 	return 0;
 }
+
 
 void TcpListener::_WaitForConnection(int listening_fd) {
     bool    end_server = false;
@@ -314,7 +331,7 @@ void TcpListener::_exec_command(Client &client, const std::string& cmd, std::vec
 	}
 }
 
-void TcpListener::_process_msg(const std::string& msg, Client	&client)
+void TcpListener::_process_msg(const std::string& msg, Client &client)
 {
 	if (!client.is_registered()) // connection procedure
 		_registration(msg, client);
@@ -374,11 +391,13 @@ Client& TcpListener::get_client(int client_fd) {
     std::list<Client*>::iterator it;
 
     for (it = this->_clients.begin(); it != this->_clients.end(); it++) {
-        if ((*it)->get_fd() == client_fd)
+        if (client_fd == (*it)->get_fd())
             return **it;
     }
 
-    throw std::runtime_error("Client not found"); // or return some default value instead of throwing an exception
+	//throw std::runtime_error("Client not found"); // or return some default value instead of throwing an exception
+	std::cout << "Client not found" << std::endl;
+	_exit(42);
 }
 
 Client &TcpListener::get_client(std::string &nick)

--- a/TcpListener.cpp
+++ b/TcpListener.cpp
@@ -177,11 +177,12 @@ int TcpListener::_handle_message(int i) {
 		return -1;
 	std::cout << "Descriptor: " << _fds[i].fd << " is readable" << std::endl;
 
+	// for registration with irssi, send whole message at once for parsing
 	if (!client.is_registered() && is_irssi_client(output)) {
 		_process_msg(output, client);
 		return 0;
 	}
-	// Wait for client to send data
+	// for everything else, send to buffer to be parsed line by line
 	while (!output.empty()) {
 		size_t pos = output.find("\r\n");
 		if (pos == std::string::npos) { // incomplete msg, keep reading or return on error

--- a/TcpListener.hpp
+++ b/TcpListener.hpp
@@ -57,6 +57,7 @@ private:
 	void			_registration(std::string msg, Client &client);
 	void			_connection(Client &client);
 	int 			_handle_new_connection(int listening_fd);
+	int 			_read_data(int fd, char *buf, std::string& buffer);
 	int 			_handle_message(int i);
 	void			_exec_command(Client &client, const std::string& cmd, std::vector<std::string> &params);
 	void			_handle_privmsg(Client &client, std::vector<std::string> &params);

--- a/utils.cpp
+++ b/utils.cpp
@@ -26,3 +26,13 @@ bool is_valid_nick(const std::string& nickname) {
     }
     return true;
 }
+
+bool	is_irssi_client(const std::string &msg) {
+	if (msg.find("CAP LS") != std::string::npos &&
+		msg.find("NICK") != std::string::npos &&
+		msg.find("USER") != std::string::npos )
+	{
+		return true;
+	}
+	return false;
+}

--- a/utils.hpp
+++ b/utils.hpp
@@ -9,5 +9,6 @@
 
 void	_skip_line(std::string &msg);
 bool	is_valid_nick(const std::string& nickname);
+bool	is_irssi_client(const std::string &msg);
 
 #endif //FT_IRC_UTILS_HPP


### PR DESCRIPTION
- bypasses buffer for connection procedure, otherwise we'd have to redesign the entire parsing of the big-intro message for connnecting
- functional buffer for all messages following the connection proc
   - If a message is lacking the trailing \r\n, it should wait indefinitely.
   - If there are several terminating \r\n in the message, it should send them one by one to the _process_msg command