### PR TITLE
Command/notice

### DIFF
--- a/Channel.cpp
+++ b/Channel.cpp
@@ -24,27 +24,6 @@ Channel& Channel::operator=(const Channel& other) {
 
 Channel::~Channel() {}
 
-bool Channel::send_notice(std::string sender, std::string usern, std::vector<std::string> &params)
-{
-	// reformat message before sending
-	std::string message = prep_message(user_id(sender, usern), "NOTICE", params);
-	std::cout << "notice for chan: " << message << std::endl;
-
-	// send message to all users in channel
-	send_to_users(sender, message);
-	return false;
-}
-
-bool Channel::send_privmsg(std::string sender, std::string usern, std::vector<std::string> &params)
-{
-	// reformat message before sending
-	std::string message = prep_message(user_id(sender, usern), "PRIVMSG", params);
-	std::cout << "msg for chan: " << message << std::endl;
-	// send message to all users in channel
-	send_to_users(sender, message);
-	return false;
-}
-
 void Channel::send_to_users(std::string sender, std::string message)
 {
 	for (std::vector<Client *>::iterator it = _users.begin(); it != _users.end(); it++)

--- a/Channel.cpp
+++ b/Channel.cpp
@@ -22,28 +22,34 @@ Channel& Channel::operator=(const Channel& other) {
 	return *this;
 }
 
-Channel::~Channel() {
+Channel::~Channel() {}
 
-}
-
-bool Channel::send_privmsg(std::string sender, std::vector<std::string> &params)
+bool Channel::send_notice(std::string sender, std::string usern, std::vector<std::string> &params)
 {
 	// reformat message before sending
-	std::string message = ":" + sender + " PRIVMSG "; // + _name + " :" + params[1] + "\r\n";
+	std::string message = prep_message(user_id(sender, usern), "NOTICE", params);
+	std::cout << "notice for chan: " << message << std::endl;
 
-	for (std::vector<std::string>::iterator it = params.begin(); it != params.end(); it++)
-		message += *it + " ";
-	std::cout << "msg for chan: " << message << std::endl;
 	// send message to all users in channel
-	send_to_users(sender, message, false);
+	send_to_users(sender, message);
 	return false;
 }
 
-void Channel::send_to_users(std::string sender, std::string message, bool self)
+bool Channel::send_privmsg(std::string sender, std::string usern, std::vector<std::string> &params)
+{
+	// reformat message before sending
+	std::string message = prep_message(user_id(sender, usern), "PRIVMSG", params);
+	std::cout << "msg for chan: " << message << std::endl;
+	// send message to all users in channel
+	send_to_users(sender, message);
+	return false;
+}
+
+void Channel::send_to_users(std::string sender, std::string message)
 {
 	for (std::vector<Client *>::iterator it = _users.begin(); it != _users.end(); it++)
 	{
-		if (!self && (*it)->get_nick() != sender)
+		if ((*it)->get_nick() != sender)
 			MessageHandler::HandleMessage((*it)->get_fd(), message + "\r\n");
 	}
 }

--- a/Channel.hpp
+++ b/Channel.hpp
@@ -29,8 +29,9 @@ public:
 	bool					is_user_in_channel(int fd);
 	void					remove_user(int fd);
 	void					add_operator(std::string nick);
-	bool					send_privmsg(std::string sender, std::vector<std::string> &params);
-	void					send_to_users(std::string sender, std::string message, bool self);
+	bool send_notice(std::string sender, std::string usern, std::vector<std::string> &params);
+	bool send_privmsg(std::string sender, std::string usern, std::vector<std::string> &params);
+	void send_to_users(std::string sender, std::string message);
 private:
     std::string _name;
     std::string _topic;

--- a/Channel.hpp
+++ b/Channel.hpp
@@ -29,9 +29,7 @@ public:
 	bool					is_user_in_channel(int fd);
 	void					remove_user(int fd);
 	void					add_operator(std::string nick);
-	bool send_notice(std::string sender, std::string usern, std::vector<std::string> &params);
-	bool send_privmsg(std::string sender, std::string usern, std::vector<std::string> &params);
-	void send_to_users(std::string sender, std::string message);
+	void					send_to_users(std::string sender, std::string message);
 private:
     std::string _name;
     std::string _topic;

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ clean:
 
 fclean:		clean
 			@ ${RM} ${NAME}
+			${RM} *.log
 			@ echo "$(RED)Deleting $(CYAN)$(NAME) $(CLR_RMV)binary ✔️"
 
 re:			fclean all

--- a/MessageHandler.cpp
+++ b/MessageHandler.cpp
@@ -15,11 +15,14 @@ void MessageHandler::numericReply(int client_fd, const std::string& numeric, con
 
 void MessageHandler::send_to_client(std::string sender, std::string type, std::vector<std::string> &params, TcpListener *SERV)
 {
+	// prep message
 	std::string message = prep_message(sender, type, params) + "\r\n";
 	std::cout << "message: " << message << std::endl;
 
+	// find client (we need his fd, but only have his name
 	Client&	client = SERV->get_client(params[0]);
 	std::cout << client.get_fd() << std::endl;
-	// SEND REFORMATED MESSAGE TO CLIENT
+
+	//send to client
 	MessageHandler::HandleMessage(client.get_fd(), message);
 }

--- a/MessageHandler.cpp
+++ b/MessageHandler.cpp
@@ -13,20 +13,13 @@ void MessageHandler::numericReply(int client_fd, const std::string& numeric, con
 	TcpListener::Send(client_fd, reply);
 }
 
-void MessageHandler::send_to_client(std::string sender, std::vector<std::string> &params, TcpListener *SERV)
+void MessageHandler::send_to_client(std::string sender, std::string type, std::vector<std::string> &params, TcpListener *SERV)
 {
-	std::string message = params[1];
+	std::string message = prep_message(sender, type, params) + "\r\n";
 	std::cout << "message: " << message << std::endl;
-	// concatenate params 2 (because is already in message) to n into string msg if it's fragmented
-	if (params.size() > 2) {
-		std::vector<std::string>::iterator it = params.begin(); it += 2;
-		for (; it != params.end(); it++)
-			message += " " + *it;
-	}
-	// FIND CLIENT USING NICKNAME
+
 	Client&	client = SERV->get_client(params[0]);
 	std::cout << client.get_fd() << std::endl;
 	// SEND REFORMATED MESSAGE TO CLIENT
-	std::string reform = ":" + sender + " PRIVMSG " + client.get_nick() + " " + message + "\r\n";
-	MessageHandler::HandleMessage(client.get_fd(), reform);
+	MessageHandler::HandleMessage(client.get_fd(), message);
 }

--- a/MessageHandler.hpp
+++ b/MessageHandler.hpp
@@ -14,7 +14,8 @@ class MessageHandler {
 public:
     static void HandleMessage(int socketId, const std::string &msg);
 	static void	numericReply(int client_fd, const std::string& numeric, const std::string& message);
-	static void send_to_client(std::string sender, std::vector<std::string> &params, TcpListener *SERV);
+	static void send_to_client(std::string sender, std::string type, std::vector<std::string> &params,
+							   TcpListener *SERV);
 };
 
 

--- a/TcpListener.hpp
+++ b/TcpListener.hpp
@@ -21,6 +21,8 @@
 #include "Client.hpp"
 
 #define BUF_SIZE 1024
+#define PRIVMSG 0
+#define NOTICE 1
 
 class Client;
 class Channel;
@@ -60,7 +62,7 @@ private:
 	int 			_read_data(int fd, char *buf, std::string& buffer);
 	int 			_handle_message(int i);
 	void			_exec_command(Client &client, const std::string& cmd, std::vector<std::string> &params);
-	void _handle_msg(Client &client, std::vector<std::string> &params, std::string type);
+	void _handle_msg(Client &client, std::string type, std::vector<std::string> &params);
 	void			_part_channel(Client &client,  std::string chan);
 
     std::string                 		_ipAddress;

--- a/TcpListener.hpp
+++ b/TcpListener.hpp
@@ -60,7 +60,7 @@ private:
 	int 			_read_data(int fd, char *buf, std::string& buffer);
 	int 			_handle_message(int i);
 	void			_exec_command(Client &client, const std::string& cmd, std::vector<std::string> &params);
-	void			_handle_privmsg(Client &client, std::vector<std::string> &params);
+	void _handle_msg(Client &client, std::vector<std::string> &params, std::string type);
 	void			_part_channel(Client &client,  std::string chan);
 
     std::string                 		_ipAddress;

--- a/utils.cpp
+++ b/utils.cpp
@@ -36,3 +36,11 @@ bool	is_irssi_client(const std::string &msg) {
 	}
 	return false;
 }
+
+std::string	prep_message(std::string sender, std::string type, std::vector<std::string> &msg)
+{
+	std::string message = ":" + sender + " " + type + " ";
+	for (std::vector<std::string>::iterator it = msg.begin(); it != msg.end(); it++)
+		message += *it + " ";
+	return message;
+}

--- a/utils.hpp
+++ b/utils.hpp
@@ -7,8 +7,9 @@
 
 #include <string>
 
-void	_skip_line(std::string &msg);
-bool	is_valid_nick(const std::string& nickname);
-bool	is_irssi_client(const std::string &msg);
+void		_skip_line(std::string &msg);
+bool		is_valid_nick(const std::string& nickname);
+bool		is_irssi_client(const std::string &msg);
+std::string	prep_message(std::string sender, std::string type, std::vector<std::string> &msg);
 
 #endif //FT_IRC_UTILS_HPP


### PR DESCRIPTION
Replaced send_notice and send_privmsg by some adjustment, leading to a one-line call to channel->send_to_users in _handle_msg that handle both cases. The prep_message function in utils compiles the params vector and adds sender, type, etc.
You can now send notices to users and channels, with the same syntax as private messages, except you use the command /notice instead of /msg.
If you're already  in a chat with a user, the notice will show up in the chat, otherwise it will show in the main client screen. If you start a chat after the first notice, the following notices are going to be in the chatbox.

Little example (users tuc and toc chat and send notices in the channel &yo, and send themselves `/privmsg` and `notice`
<img width="1054" alt="image" src="https://user-images.githubusercontent.com/88668425/230780424-8c99d174-7774-48b2-a5a9-c2c8b7f26e1c.png">
