### PR TITLE
Nickname fix

### DIFF
--- a/Client.cpp
+++ b/Client.cpp
@@ -41,9 +41,10 @@ bool Client::set_nickname(const std::string &nick, TcpListener &SERV) {
         if (_registered) {
             MessageHandler::numericReply(_clientFd, "433", _username + " " + trimmed_nick + " :Nickname is already in use");
         } else {
-			MessageHandler::HandleMessage(_clientFd, trimmed_nick + " " + trimmed_nick + " :Nickname is already in use");
+			MessageHandler::HandleMessage(_clientFd, trimmed_nick + " " + trimmed_nick + " :Nickname is already in use\r\n");
 		}
-		SERV._disconnect_client(*this, "Client disconnected");
+		if (!this->_connected)
+			SERV._disconnect_client(*this, "Client disconnected");
         return false;
     }
 }

--- a/TcpListener.hpp
+++ b/TcpListener.hpp
@@ -59,7 +59,7 @@ private:
 	int 			_read_data(int fd, char *buf, std::string& buffer);
 	int 			_handle_message(int i);
 	void			_exec_command(Client &client, const std::string& cmd, std::vector<std::string> &params);
-	void _handle_msg(Client &client, std::string type, std::vector<std::string> &params);
+	void			_handle_msg(Client &client, std::string type, std::vector<std::string> &params);
 	void			_part_channel(Client &client,  std::string chan);
 
     std::string                 		_ipAddress;


### PR DESCRIPTION
- Trying to change nickname to an existing one when connected, doesn't disconnect you, just sends the numeric reply for the error.
- When you're not connected yet and you try to register with an already existing nickname, the numeric reply for the error is sent, and the disconnection error message is sent, this time with the \r\n that was missing